### PR TITLE
Add support for compiling KDE notifier against KF5/Qt5

### DIFF
--- a/qcma.pro
+++ b/qcma.pro
@@ -20,9 +20,6 @@ unix:!macx:!android {
         SUBDIRS += qcma_appindicator.pro
     }
     ENABLE_KDENOTIFIER {
-        greaterThan(QT_MAJOR_VERSION, 4) {
-            error("ENABLE_KDE can only be used with Qt4")
-        }
         SUBDIRS += qcma_kdenotifier.pro
     }
 }

--- a/qcma_kdenotifier.pro
+++ b/qcma_kdenotifier.pro
@@ -5,8 +5,13 @@ TEMPLATE = lib
 CONFIG += plugin
 DEFINES += QCMA_TRAYINDICATOR_LIBRARY
 PKGCONFIG =
-LIBS += -lkdeui
 INCLUDEPATH += src/
+
+greaterThan(QT_MAJOR_VERSION, 4) {
+    QT += KNotifications
+} else {
+    LIBS += -lkdeui
+}
 
 SOURCES += \
     src/indicator/kdenotifier.cpp \

--- a/src/gui/mainwidget.cpp
+++ b/src/gui/mainwidget.cpp
@@ -219,7 +219,6 @@ TrayIndicator *MainWidget::createTrayObject(QWidget *parent)
     QString desktop = getenv("XDG_CURRENT_DESKTOP");
     qDebug() << "Current desktop: " << desktop;
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     if(desktop.toLower() == "kde")
     {
         // KDENotifier
@@ -230,7 +229,6 @@ TrayIndicator *MainWidget::createTrayObject(QWidget *parent)
             qDebug() << "Cannot load libqcma_kdenotifier plugin";
     }
     else
-#endif
     // try to use the appindicator if is available
     // if(desktop.toLower() == "unity")
     {

--- a/src/indicator/kdenotifier.h
+++ b/src/indicator/kdenotifier.h
@@ -21,7 +21,9 @@
 #define KDENOTIFIER_H
 
 #include <kstatusnotifieritem.h>
+#if QT_VERSION < 0x050000
 #include <kmenu.h>
+#endif
 
 class KDENotifier : public KStatusNotifierItem
 {

--- a/src/indicator/kdenotifiertray.cpp
+++ b/src/indicator/kdenotifiertray.cpp
@@ -18,7 +18,11 @@
  */
 
 #include "kdenotifiertray.h"
+#if QT_VERSION < 0x050000
 #include <kmenu.h>
+#else
+#include <QMenu>
+#endif
 
 KDENotifierTray::KDENotifierTray(QWidget *parent)
     : TrayIndicator(parent)
@@ -41,7 +45,11 @@ void KDENotifierTray::init()
     connect(about_qt, SIGNAL(triggered()), this, SIGNAL(showAboutQt()));
     connect(quit, SIGNAL(triggered()), this, SIGNAL(stopServer()));
 
+#if QT_VERSION < 0x050000
     KMenu *tray_icon_menu = new KMenu(this);
+#else
+    QMenu *tray_icon_menu = new QMenu(this);
+#endif
 
     tray_icon_menu->addAction(options);
     tray_icon_menu->addAction(reload);


### PR DESCRIPTION
Required to see tray icon on new Plasma 5 with Qt older than 5.4
