### PR TITLE
add sample systemd system service

### DIFF
--- a/systemd/system/qcma.service
+++ b/systemd/system/qcma.service
@@ -1,0 +1,13 @@
+[Unit]
+Description="Qcma daemon"
+Documentation=man:qcma_cli(6)
+ConditionPathExists=/home/qcma/.config/codestation/qcma.conf
+
+[Service]
+ExecStart=/usr/bin/qcma_cli --verbose
+ExecReload=/bin/kill -HUP $MAINPID
+User=qcma
+
+[Install]
+Alias=qcma_cli.service
+WantedBy=default.target


### PR DESCRIPTION
this needs some manual setup:
- creation of un-privilieged user 'qcma'
- add config file
- systemctl enable
- systemctl start

--

making qcma_cli really FHS-compliant means a lot more work: 
- using QSettings::SystemScope & setPath('/etc/qcma.conf')
- storing data in /var/lib/qcam/